### PR TITLE
Return cached communities if avaliable

### DIFF
--- a/lemmy.py
+++ b/lemmy.py
@@ -39,6 +39,11 @@ class Lemmy:
 
     def get_communities(self, type: str = "Subscribed") -> list:
         """Get list of currently subscribed communites"""
+        
+        # Return cached communities if already fetched
+        if self._user_communities:
+            return self._user_communities
+        
         payload = {"type_": type, "auth": self._auth_token, "limit": 50, "page": 1}
 
         # iterate over each page if needed


### PR DESCRIPTION
(cherry picked from commit 1bed7fac10a411d66e33332536602a2894c42031)

If an instance's communities are already cached, use them vs fetching again.