### PR TITLE
Use Authorization header for requests (Lemmy v.0.19)

### DIFF
--- a/lemmy.py
+++ b/lemmy.py
@@ -135,8 +135,10 @@ class Lemmy:
         json: Optional[dict] = None,
     ) -> requests.Response:
         self._rate_limit()
+        token = self._auth_token
+        headers = {'Authorization': f'Bearer {token}'}
         try:
-            r = requests.request(method, url=endpoint, params=params, json=json)
+            r = requests.request(method, url=endpoint, params=params, json=json, headers=headers)
             r.raise_for_status()
             return r
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Lemmy v0.19 now expects the auth token to be send via header (or cookie): https://github.com/LemmyNet/lemmy/pull/3725
See also release announcement: https://join-lemmy.org/news/2023-12-15_-_Lemmy_Release_v0.19.0_-_Instance_blocking,_Scaled_sort,_and_Federation_Queue

With this change I was able to subscribe to communities on feddit.de which uses v0.19 already.

Let me know if you have any feedback on this PR to get it merged @wescode 